### PR TITLE
Add workaround when dependency errs or is not found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ obj/
 /.idea/
 /.vs/
 .DS_Store
+Freshli.sln.DotSettings.user
+*.log

--- a/Freshli/Exceptions/DependencyNotFoundException.cs
+++ b/Freshli/Exceptions/DependencyNotFoundException.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Freshli.Exceptions {
+  public class DependencyNotFoundException : Exception {
+
+    public DependencyNotFoundException(string dependency)
+      : base($"Unable to find dependency {dependency}.")
+    {
+    }
+
+  }
+}

--- a/Freshli/Exceptions/LatestVersionNotFoundException.cs
+++ b/Freshli/Exceptions/LatestVersionNotFoundException.cs
@@ -4,7 +4,8 @@ namespace Freshli.Exceptions {
   public class LatestVersionNotFoundException : Exception {
 
     public LatestVersionNotFoundException(DateTime date, string dependency)
-      : base($"Unable to find latest version of dependency {dependency} as of {date:d}.")
+      : base($"Unable to find latest version of dependency " +
+        $"{dependency} as of {date:d}.")
     {
     }
 

--- a/Freshli/Exceptions/LatestVersionNotFoundException.cs
+++ b/Freshli/Exceptions/LatestVersionNotFoundException.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Freshli.Exceptions {
+  public class LatestVersionNotFoundException : Exception {
+
+    public LatestVersionNotFoundException(DateTime date, string dependency)
+      : base($"Unable to find latest version of dependency {dependency} as of {date:d}.")
+    {
+    }
+
+  }
+}

--- a/Freshli/Languages/Ruby/RubyGemsRepository.cs
+++ b/Freshli/Languages/Ruby/RubyGemsRepository.cs
@@ -1,12 +1,16 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Freshli.Exceptions;
 using RestSharp;
 
 namespace Freshli.Languages.Ruby {
   public class RubyGemsRepository : IPackageRepository {
     public VersionInfo LatestAsOf(DateTime date, string name) {
       var response = ApiRequest(name);
+      if (response == null) {
+        throw new DependencyNotFoundException(name);
+      }
 
       var candidates = response.
         Where(version => !version.Prerelease && version.CreatedAt <= date).
@@ -20,7 +24,7 @@ namespace Freshli.Languages.Ruby {
         );
       }
 
-      return null;
+      throw new LatestVersionNotFoundException(date, name);
     }
 
     private Dictionary<String, List<RubyGemsVersion>> _responseCache =

--- a/Freshli/LibYearCalculator.cs
+++ b/Freshli/LibYearCalculator.cs
@@ -19,7 +19,14 @@ namespace Freshli {
       var result = new LibYearResult();
 
       foreach (var package in Manifest) {
-        var latestVersion = Repository.LatestAsOf(date, package.Name);
+        VersionInfo latestVersion;
+        try {
+          latestVersion = Repository.LatestAsOf(date, package.Name);
+        } catch (Exception e) {
+          _logger.Info($"Skipping {package.Name}: {e.Message}");
+          continue;
+        }
+
         VersionInfo currentVersion;
         if (Manifest.UsesExactMatches) {
           currentVersion =

--- a/Freshli/LibYearCalculator.cs
+++ b/Freshli/LibYearCalculator.cs
@@ -43,9 +43,9 @@ namespace Freshli {
           _logger.Trace(
             $"Package({package.Name}, {package.Version}): " +
             $"current = {currentVersion.ToSemVer()}" +
-            $"@{currentVersion.DatePublished}, " +
+            $"@{currentVersion.DatePublished:d}, " +
             $"latest = {latestVersion.ToSemVer()}" +
-            $"@{latestVersion.DatePublished}"
+            $"@{latestVersion.DatePublished:d}"
           );
           result.Add(
             package.Name,

--- a/Freshli/LibYearCalculator.cs
+++ b/Freshli/LibYearCalculator.cs
@@ -21,7 +21,7 @@ namespace Freshli {
       foreach (var package in Manifest) {
         VersionInfo latestVersion;
         VersionInfo currentVersion;
-        
+
         try {
           latestVersion = Repository.LatestAsOf(date, package.Name);
 

--- a/Freshli/LibYearCalculator.cs
+++ b/Freshli/LibYearCalculator.cs
@@ -20,23 +20,24 @@ namespace Freshli {
 
       foreach (var package in Manifest) {
         VersionInfo latestVersion;
+        VersionInfo currentVersion;
+        
         try {
           latestVersion = Repository.LatestAsOf(date, package.Name);
-        } catch (Exception e) {
-          _logger.Info($"Skipping {package.Name}: {e.Message}");
-          continue;
-        }
 
-        VersionInfo currentVersion;
-        if (Manifest.UsesExactMatches) {
-          currentVersion =
-            Repository.VersionInfo(package.Name, package.Version);
-        } else {
-          currentVersion = Repository.Latest(
-            package.Name,
-            package.Version,
-            asOf: date
-          );
+          if (Manifest.UsesExactMatches) {
+            currentVersion =
+              Repository.VersionInfo(package.Name, package.Version);
+          } else {
+            currentVersion = Repository.Latest(
+              package.Name,
+              package.Version,
+              asOf: date
+            );
+          }
+        } catch (Exception e) {
+          _logger.Warn($"Skipping {package.Name}: {e.Message}");
+          continue;
         }
 
         if (latestVersion != null && currentVersion != null) {

--- a/Freshli/Program.cs
+++ b/Freshli/Program.cs
@@ -7,7 +7,7 @@ namespace Freshli {
     private static readonly Logger logger = LogManager.GetCurrentClassLogger();
 
     static void Main(string[] args) {
-      logger.Info($"Main({args})");
+      logger.Info($"Main({string.Join(separator: ",", args)})");
 
       try {
         ManifestFinder.RegisterAll();

--- a/Freshli/Program.cs
+++ b/Freshli/Program.cs
@@ -1,10 +1,5 @@
 ﻿using System;
 using System.IO;
-using System.Linq;
-using System.Reflection;
-using Freshli.Languages.Php;
-using Freshli.Languages.Python;
-using Freshli.Languages.Ruby;
 using NLog;
 
 namespace Freshli {
@@ -33,6 +28,7 @@ namespace Freshli {
           e,
           $"Exception executing Freshli for args = {args}: {e.Message}"
         );
+        logger.Trace(e, e.StackTrace);
       }
     }
 

--- a/Freshli/Runner.cs
+++ b/Freshli/Runner.cs
@@ -7,7 +7,7 @@ namespace Freshli {
     private static readonly Logger logger = LogManager.GetCurrentClassLogger();
 
     public IList<MetricsResult> Run(string analysisPath, DateTime asOf) {
-      logger.Info($"Run({analysisPath}, {asOf})");
+      logger.Info($"Run({analysisPath}, {asOf:d})");
 
       var metricsResults = new List<MetricsResult>();
 

--- a/Freshli/Runner.cs
+++ b/Freshli/Runner.cs
@@ -36,8 +36,8 @@ namespace Freshli {
 
           LibYearResult libYear = calculator.ComputeAsOf(currentDate);
           logger.Trace(
-            "Adding MetricResult: " +
-            "currentDate = {currentDate}, " +
+            "Adding MetricResult: {manifestFile}, " +
+            "currentDate = {currentDate:d}, " +
             "libYear = {ComputeAsOf}",
             manifestFinder.LockFileName,
             currentDate,

--- a/Freshli/Runner.cs
+++ b/Freshli/Runner.cs
@@ -34,18 +34,19 @@ namespace Freshli {
           var content = fileHistory.ContentsAsOf(currentDate);
           calculator.Manifest.Parse(content);
 
+          LibYearResult libYear = calculator.ComputeAsOf(currentDate);
           logger.Trace(
             "Adding MetricResult: " +
             "currentDate = {currentDate}, " +
             "libYear = {ComputeAsOf}",
             manifestFinder.LockFileName,
             currentDate,
-            calculator.ComputeAsOf(currentDate).Total
+            libYear.Total
           );
           metricsResults.Add(
             new MetricsResult(
               currentDate,
-              calculator.ComputeAsOf(currentDate)
+              libYear
             )
           );
         }


### PR DESCRIPTION
Makes updates to initially resolve the following issues:

- #27 (https://github.com/chriskiehl/Gooey)
- #32 (https://github.com/HelloZeroNet/ZeroNet)
- #33 (https://github.com/diaspora/diaspora)
- #35 (https://github.com/gitlabhq/gitlabhq)
- #36 (https://github.com/discourse/discourse)

Note - these updates simply allow Freshli to successfully complete a run against the given repositories. The current logic simply skips problematic dependencies. These problematic dependencies still need to be investigated separately. 