### PR TITLE
#110 & #112 - Avoid duplicate requests & DOS attacks

### DIFF
--- a/Freshli.Web/Controllers/AnalysisRequestsController.cs
+++ b/Freshli.Web/Controllers/AnalysisRequestsController.cs
@@ -43,8 +43,9 @@ namespace Freshli.Web.Controllers {
         FirstOrDefault(request => request.Url == analysisRequest.Url);
 
       if (existingRequest != null) {
-        existingRequest.State = AnalysisRequestState.Retrying;
-        _db.AnalysisRequests.Update(existingRequest);
+        analysisRequest = existingRequest;
+        analysisRequest.State = AnalysisRequestState.Retrying;
+        _db.AnalysisRequests.Update(analysisRequest);
       } else {
         analysisRequest.State = AnalysisRequestState.New;
         _db.AnalysisRequests.Add(analysisRequest);

--- a/Freshli.Web/Controllers/AnalysisRequestsController.cs
+++ b/Freshli.Web/Controllers/AnalysisRequestsController.cs
@@ -44,8 +44,11 @@ namespace Freshli.Web.Controllers {
 
       if (existingRequest != null) {
         analysisRequest = existingRequest;
-        analysisRequest.State = AnalysisRequestState.Retrying;
-        _db.AnalysisRequests.Update(analysisRequest);
+        if (existingRequest.State != AnalysisRequestState.Retrying &&
+          existingRequest.State != AnalysisRequestState.InProgress) {
+          analysisRequest.State = AnalysisRequestState.Retrying;
+          _db.AnalysisRequests.Update(analysisRequest);
+        }
       } else {
         analysisRequest.State = AnalysisRequestState.New;
         _db.AnalysisRequests.Add(analysisRequest);

--- a/Freshli.Web/Controllers/AnalysisRequestsController.cs
+++ b/Freshli.Web/Controllers/AnalysisRequestsController.cs
@@ -37,8 +37,18 @@ namespace Freshli.Web.Controllers {
         return View();
       }
 
-      analysisRequest.State = AnalysisRequestState.New;
-      _db.AnalysisRequests.Add(analysisRequest);
+      var existingRequest = _db.AnalysisRequests.
+        Where(request => request.Name == analysisRequest.Name.Trim()).
+        Where(request => request.Email == analysisRequest.Email).
+        FirstOrDefault(request => request.Url == analysisRequest.Url);
+
+      if (existingRequest != null) {
+        existingRequest.State = AnalysisRequestState.Retrying;
+        _db.AnalysisRequests.Update(existingRequest);
+      } else {
+        analysisRequest.State = AnalysisRequestState.New;
+        _db.AnalysisRequests.Add(analysisRequest);
+      }
       _db.SaveChanges();
 
       EmailHelper.SendKickoffEmail(analysisRequest);


### PR DESCRIPTION
Per #110 updates the controller logic to reuse the existing GUID for duplicate requests.

And, per #112, updates the controller logic to request a re-run only if an existing run isn't still running.