### PR TITLE
#153 - Add support for Ruby pre-release versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -437,4 +437,5 @@ Acceptance.*.received.txt
 
 Freshli.sln.DotSettings.user
 *.log
+results/
 

--- a/Freshli.Test/Acceptance.RubyGemsClearanceHistoryViaGitHub.approved.txt
+++ b/Freshli.Test/Acceptance.RubyGemsClearanceHistoryViaGitHub.approved.txt
@@ -1921,6 +1921,7 @@ results[30] = { Date: 2013-09-01T00:00:00, ManifestSHA: 94db124c9d8f834e6ec76b4d
 { Name: "rubyzip", RepoVersion: "0.9.9", RepoVersionPublishedAt: 2012-06-17T00:00:00, LatestVersion: "1.0.0", LatestPublishedAt: 2013-08-29T00:00:00, UpgradeAvailable: True, Value: 1.2 },
 { Name: "sdoc", RepoVersion: "0.3.20", RepoVersionPublishedAt: 2012-11-21T00:00:00, LatestVersion: "0.3.20", LatestPublishedAt: 2012-11-21T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "selenium-webdriver", RepoVersion: "2.33.0", RepoVersionPublishedAt: 2013-05-26T00:00:00, LatestVersion: "2.35.1", LatestPublishedAt: 2013-08-26T00:00:00, UpgradeAvailable: True, Value: 0.25205479452054796 },
+{ Name: "shoulda-matchers", RepoVersion: "2.4.0.rc1", RepoVersionPublishedAt: 2013-08-16T00:00:00, LatestVersion: "2.4.0.rc1", LatestPublishedAt: 2013-08-16T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "sprockets", RepoVersion: "2.10.0", RepoVersionPublishedAt: 2013-05-24T00:00:00, LatestVersion: "2.10.0", LatestPublishedAt: 2013-05-24T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "sprockets-rails", RepoVersion: "2.0.0", RepoVersionPublishedAt: 2013-06-11T00:00:00, LatestVersion: "2.0.0", LatestPublishedAt: 2013-06-11T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "sqlite3", RepoVersion: "1.3.7", RepoVersionPublishedAt: 2013-01-12T00:00:00, LatestVersion: "1.3.8", LatestPublishedAt: 2013-08-17T00:00:00, UpgradeAvailable: True, Value: 0.5945205479452055 },
@@ -1987,6 +1988,7 @@ results[31] = { Date: 2013-10-01T00:00:00, ManifestSHA: 988ecbde705cc47c7889075c
 { Name: "rubyzip", RepoVersion: "0.9.9", RepoVersionPublishedAt: 2012-06-17T00:00:00, LatestVersion: "1.0.0", LatestPublishedAt: 2013-08-29T00:00:00, UpgradeAvailable: True, Value: 1.2 },
 { Name: "sdoc", RepoVersion: "0.3.20", RepoVersionPublishedAt: 2012-11-21T00:00:00, LatestVersion: "0.3.20", LatestPublishedAt: 2012-11-21T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "selenium-webdriver", RepoVersion: "2.33.0", RepoVersionPublishedAt: 2013-05-26T00:00:00, LatestVersion: "2.35.1", LatestPublishedAt: 2013-08-26T00:00:00, UpgradeAvailable: True, Value: 0.25205479452054796 },
+{ Name: "shoulda-matchers", RepoVersion: "2.4.0.rc1", RepoVersionPublishedAt: 2013-08-16T00:00:00, LatestVersion: "2.4.0", LatestPublishedAt: 2013-09-20T00:00:00, UpgradeAvailable: True, Value: 0.0958904109589041 },
 { Name: "sprockets", RepoVersion: "2.10.0", RepoVersionPublishedAt: 2013-05-24T00:00:00, LatestVersion: "2.10.0", LatestPublishedAt: 2013-05-24T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "sprockets-rails", RepoVersion: "2.0.0", RepoVersionPublishedAt: 2013-06-11T00:00:00, LatestVersion: "2.0.0", LatestPublishedAt: 2013-06-11T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "sqlite3", RepoVersion: "1.3.7", RepoVersionPublishedAt: 2013-01-12T00:00:00, LatestVersion: "1.3.8", LatestPublishedAt: 2013-08-17T00:00:00, UpgradeAvailable: True, Value: 0.5945205479452055 },
@@ -1998,7 +2000,7 @@ results[31] = { Date: 2013-10-01T00:00:00, ManifestSHA: 988ecbde705cc47c7889075c
 { Name: "tzinfo", RepoVersion: "0.3.37", RepoVersionPublishedAt: 2013-03-11T00:00:00, LatestVersion: "1.1.0", LatestPublishedAt: 2013-09-25T00:00:00, UpgradeAvailable: True, Value: 0.5424657534246575 },
 { Name: "websocket", RepoVersion: "1.0.7", RepoVersionPublishedAt: 2013-01-27T00:00:00, LatestVersion: "1.1.1", LatestPublishedAt: 2013-07-02T00:00:00, UpgradeAvailable: True, Value: 0.4273972602739726 },
 { Name: "xpath", RepoVersion: "1.0.0", RepoVersionPublishedAt: 2012-11-14T00:00:00, LatestVersion: "2.0.0", LatestPublishedAt: 2013-04-09T00:00:00, UpgradeAvailable: True, Value: 0.4 },
-], Total: 7.986301369863016 } }
+], Total: 8.08219178082192 } }
 
 results[32] = { Date: 2013-11-01T00:00:00, ManifestSHA: 2c930b0d0a7b8569e34ed27b0e9ab8d94a90caf9, LibYear: { _packagesValues: [
 { Name: "actionmailer", RepoVersion: "4.0.0", RepoVersionPublishedAt: 2013-06-25T00:00:00, LatestVersion: "4.0.1", LatestPublishedAt: 2013-11-01T00:00:00, UpgradeAvailable: True, Value: 0.35342465753424657 },
@@ -2053,6 +2055,7 @@ results[32] = { Date: 2013-11-01T00:00:00, ManifestSHA: 2c930b0d0a7b8569e34ed27b
 { Name: "rubyzip", RepoVersion: "0.9.9", RepoVersionPublishedAt: 2012-06-17T00:00:00, LatestVersion: "1.1.0", LatestPublishedAt: 2013-11-01T00:00:00, UpgradeAvailable: True, Value: 1.3753424657534246 },
 { Name: "sdoc", RepoVersion: "0.3.20", RepoVersionPublishedAt: 2012-11-21T00:00:00, LatestVersion: "0.3.20", LatestPublishedAt: 2012-11-21T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "selenium-webdriver", RepoVersion: "2.33.0", RepoVersionPublishedAt: 2013-05-26T00:00:00, LatestVersion: "2.37.0", LatestPublishedAt: 2013-10-18T00:00:00, UpgradeAvailable: True, Value: 0.3972602739726027 },
+{ Name: "shoulda-matchers", RepoVersion: "2.4.0.rc1", RepoVersionPublishedAt: 2013-08-16T00:00:00, LatestVersion: "2.4.0", LatestPublishedAt: 2013-09-20T00:00:00, UpgradeAvailable: True, Value: 0.0958904109589041 },
 { Name: "sprockets", RepoVersion: "2.10.0", RepoVersionPublishedAt: 2013-05-24T00:00:00, LatestVersion: "2.10.0", LatestPublishedAt: 2013-05-24T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "sprockets-rails", RepoVersion: "2.0.0", RepoVersionPublishedAt: 2013-06-11T00:00:00, LatestVersion: "2.0.1", LatestPublishedAt: 2013-10-16T00:00:00, UpgradeAvailable: True, Value: 0.34794520547945207 },
 { Name: "sqlite3", RepoVersion: "1.3.7", RepoVersionPublishedAt: 2013-01-12T00:00:00, LatestVersion: "1.3.8", LatestPublishedAt: 2013-08-17T00:00:00, UpgradeAvailable: True, Value: 0.5945205479452055 },
@@ -2064,7 +2067,7 @@ results[32] = { Date: 2013-11-01T00:00:00, ManifestSHA: 2c930b0d0a7b8569e34ed27b
 { Name: "tzinfo", RepoVersion: "0.3.37", RepoVersionPublishedAt: 2013-03-11T00:00:00, LatestVersion: "1.1.0", LatestPublishedAt: 2013-09-25T00:00:00, UpgradeAvailable: True, Value: 0.5424657534246575 },
 { Name: "websocket", RepoVersion: "1.0.7", RepoVersionPublishedAt: 2013-01-27T00:00:00, LatestVersion: "1.1.1", LatestPublishedAt: 2013-07-02T00:00:00, UpgradeAvailable: True, Value: 0.4273972602739726 },
 { Name: "xpath", RepoVersion: "1.0.0", RepoVersionPublishedAt: 2012-11-14T00:00:00, LatestVersion: "2.0.0", LatestPublishedAt: 2013-04-09T00:00:00, UpgradeAvailable: True, Value: 0.4 },
-], Total: 13.906849315068492 } }
+], Total: 14.002739726027396 } }
 
 results[33] = { Date: 2013-12-01T00:00:00, ManifestSHA: 18db3c7294a823a3a401182d869a4e4840ee4a0d, LibYear: { _packagesValues: [
 { Name: "actionmailer", RepoVersion: "4.0.0", RepoVersionPublishedAt: 2013-06-25T00:00:00, LatestVersion: "4.0.1", LatestPublishedAt: 2013-11-01T00:00:00, UpgradeAvailable: True, Value: 0.35342465753424657 },

--- a/Freshli.Test/Acceptance.RubyGemsFeedbinHistoryViaGitHub.approved.txt
+++ b/Freshli.Test/Acceptance.RubyGemsFeedbinHistoryViaGitHub.approved.txt
@@ -86,6 +86,7 @@
 { Name: "sanitize", RepoVersion: "2.0.6", RepoVersionPublishedAt: 2013-07-11T00:00:00, LatestVersion: "2.0.6", LatestPublishedAt: 2013-07-11T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "sass", RepoVersion: "3.2.10", RepoVersionPublishedAt: 2013-07-27T00:00:00, LatestVersion: "3.2.10", LatestPublishedAt: 2013-07-27T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "sass-rails", RepoVersion: "4.0.0", RepoVersionPublishedAt: 2013-06-25T00:00:00, LatestVersion: "4.0.0", LatestPublishedAt: 2013-06-25T00:00:00, UpgradeAvailable: False, Value: 0 },
+{ Name: "sax-machine", RepoVersion: "0.2.0.rc1", RepoVersionPublishedAt: 2012-06-04T00:00:00, LatestVersion: "0.2.0.rc1", LatestPublishedAt: 2012-06-04T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "sidekiq", RepoVersion: "2.13.1", RepoVersionPublishedAt: 2013-08-10T00:00:00, LatestVersion: "2.14.0", LatestPublishedAt: 2013-08-25T00:00:00, UpgradeAvailable: True, Value: 0.0410958904109589 },
 { Name: "sinatra", RepoVersion: "1.4.3", RepoVersionPublishedAt: 2013-06-07T00:00:00, LatestVersion: "1.4.3", LatestPublishedAt: 2013-06-07T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "slim", RepoVersion: "2.0.1", RepoVersionPublishedAt: 2013-07-30T00:00:00, LatestVersion: "2.0.1", LatestPublishedAt: 2013-07-30T00:00:00, UpgradeAvailable: False, Value: 0 },
@@ -196,6 +197,7 @@ results[1] = { Date: 2013-10-01T00:00:00, ManifestSHA: 1ea3203331b3a6f86d0a03e6c
 { Name: "sanitize", RepoVersion: "2.0.6", RepoVersionPublishedAt: 2013-07-11T00:00:00, LatestVersion: "2.0.6", LatestPublishedAt: 2013-07-11T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "sass", RepoVersion: "3.2.10", RepoVersionPublishedAt: 2013-07-27T00:00:00, LatestVersion: "3.2.11", LatestPublishedAt: 2013-09-28T00:00:00, UpgradeAvailable: True, Value: 0.1726027397260274 },
 { Name: "sass-rails", RepoVersion: "4.0.0", RepoVersionPublishedAt: 2013-06-25T00:00:00, LatestVersion: "4.0.0", LatestPublishedAt: 2013-06-25T00:00:00, UpgradeAvailable: False, Value: 0 },
+{ Name: "sax-machine", RepoVersion: "0.2.0.rc1", RepoVersionPublishedAt: 2012-06-04T00:00:00, LatestVersion: "0.2.0.rc1", LatestPublishedAt: 2012-06-04T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "sidekiq", RepoVersion: "2.14.1", RepoVersionPublishedAt: 2013-09-13T00:00:00, LatestVersion: "2.15.0", LatestPublishedAt: 2013-10-01T00:00:00, UpgradeAvailable: True, Value: 0.049315068493150684 },
 { Name: "sinatra", RepoVersion: "1.4.3", RepoVersionPublishedAt: 2013-06-07T00:00:00, LatestVersion: "1.4.3", LatestPublishedAt: 2013-06-07T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "slim", RepoVersion: "2.0.1", RepoVersionPublishedAt: 2013-07-30T00:00:00, LatestVersion: "2.0.1", LatestPublishedAt: 2013-07-30T00:00:00, UpgradeAvailable: False, Value: 0 },
@@ -313,6 +315,7 @@ results[2] = { Date: 2013-11-01T00:00:00, ManifestSHA: 100fb897c8bc70147e58196d8
 { Name: "sanitize", RepoVersion: "2.0.6", RepoVersionPublishedAt: 2013-07-11T00:00:00, LatestVersion: "2.0.6", LatestPublishedAt: 2013-07-11T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "sass", RepoVersion: "3.2.12", RepoVersionPublishedAt: 2013-10-05T00:00:00, LatestVersion: "3.2.12", LatestPublishedAt: 2013-10-05T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "sass-rails", RepoVersion: "4.0.1", RepoVersionPublishedAt: 2013-10-15T00:00:00, LatestVersion: "4.0.1", LatestPublishedAt: 2013-10-15T00:00:00, UpgradeAvailable: False, Value: 0 },
+{ Name: "sax-machine", RepoVersion: "0.2.0.rc1", RepoVersionPublishedAt: 2012-06-04T00:00:00, LatestVersion: "0.2.1", LatestPublishedAt: 2013-10-14T00:00:00, UpgradeAvailable: True, Value: 1.3616438356164384 },
 { Name: "sidekiq", RepoVersion: "2.16.1", RepoVersionPublishedAt: 2013-10-31T00:00:00, LatestVersion: "2.16.1", LatestPublishedAt: 2013-10-31T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "sinatra", RepoVersion: "1.4.4", RepoVersionPublishedAt: 2013-10-21T00:00:00, LatestVersion: "1.4.4", LatestPublishedAt: 2013-10-21T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "sprockets", RepoVersion: "2.10.0", RepoVersionPublishedAt: 2013-05-24T00:00:00, LatestVersion: "2.10.0", LatestPublishedAt: 2013-05-24T00:00:00, UpgradeAvailable: False, Value: 0 },
@@ -332,7 +335,7 @@ results[2] = { Date: 2013-11-01T00:00:00, ManifestSHA: 100fb897c8bc70147e58196d8
 { Name: "uuidtools", RepoVersion: "2.1.4", RepoVersionPublishedAt: 2013-04-25T00:00:00, LatestVersion: "2.1.4", LatestPublishedAt: 2013-04-25T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "will_paginate", RepoVersion: "3.0.5", RepoVersionPublishedAt: 2013-09-18T00:00:00, LatestVersion: "3.0.5", LatestPublishedAt: 2013-09-18T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "yajl-ruby", RepoVersion: "1.1.0", RepoVersionPublishedAt: 2011-11-09T00:00:00, LatestVersion: "1.1.0", LatestPublishedAt: 2011-11-09T00:00:00, UpgradeAvailable: False, Value: 0 },
-], Total: 8.556164383561644 } }
+], Total: 9.917808219178083 } }
 
 results[3] = { Date: 2013-12-01T00:00:00, ManifestSHA: 841b4bfaf022294afac2ed4c28bc94a0a4b50463, LibYear: { _packagesValues: [
 { Name: "actionmailer", RepoVersion: "4.0.0", RepoVersionPublishedAt: 2013-06-25T00:00:00, LatestVersion: "4.0.1", LatestPublishedAt: 2013-11-01T00:00:00, UpgradeAvailable: True, Value: 0.35342465753424657 },
@@ -422,6 +425,7 @@ results[3] = { Date: 2013-12-01T00:00:00, ManifestSHA: 841b4bfaf022294afac2ed4c2
 { Name: "sanitize", RepoVersion: "2.0.6", RepoVersionPublishedAt: 2013-07-11T00:00:00, LatestVersion: "2.0.6", LatestPublishedAt: 2013-07-11T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "sass", RepoVersion: "3.2.10", RepoVersionPublishedAt: 2013-07-27T00:00:00, LatestVersion: "3.2.12", LatestPublishedAt: 2013-10-05T00:00:00, UpgradeAvailable: True, Value: 0.1917808219178082 },
 { Name: "sass-rails", RepoVersion: "4.0.0", RepoVersionPublishedAt: 2013-06-25T00:00:00, LatestVersion: "4.0.1", LatestPublishedAt: 2013-10-15T00:00:00, UpgradeAvailable: True, Value: 0.30684931506849317 },
+{ Name: "sax-machine", RepoVersion: "0.2.0.rc1", RepoVersionPublishedAt: 2012-06-04T00:00:00, LatestVersion: "0.2.1", LatestPublishedAt: 2013-10-14T00:00:00, UpgradeAvailable: True, Value: 1.3616438356164384 },
 { Name: "sidekiq", RepoVersion: "2.14.1", RepoVersionPublishedAt: 2013-09-13T00:00:00, LatestVersion: "2.17.0", LatestPublishedAt: 2013-11-24T00:00:00, UpgradeAvailable: True, Value: 0.19726027397260273 },
 { Name: "sinatra", RepoVersion: "1.4.3", RepoVersionPublishedAt: 2013-06-07T00:00:00, LatestVersion: "1.4.4", LatestPublishedAt: 2013-10-21T00:00:00, UpgradeAvailable: True, Value: 0.3726027397260274 },
 { Name: "slim", RepoVersion: "2.0.1", RepoVersionPublishedAt: 2013-07-30T00:00:00, LatestVersion: "2.0.2", LatestPublishedAt: 2013-10-27T00:00:00, UpgradeAvailable: True, Value: 0.24383561643835616 },
@@ -442,7 +446,7 @@ results[3] = { Date: 2013-12-01T00:00:00, ManifestSHA: 841b4bfaf022294afac2ed4c2
 { Name: "uuidtools", RepoVersion: "2.1.4", RepoVersionPublishedAt: 2013-04-25T00:00:00, LatestVersion: "2.1.4", LatestPublishedAt: 2013-04-25T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "will_paginate", RepoVersion: "3.0.5", RepoVersionPublishedAt: 2013-09-18T00:00:00, LatestVersion: "3.0.5", LatestPublishedAt: 2013-09-18T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "yajl-ruby", RepoVersion: "1.1.0", RepoVersionPublishedAt: 2011-11-09T00:00:00, LatestVersion: "1.1.0", LatestPublishedAt: 2011-11-09T00:00:00, UpgradeAvailable: False, Value: 0 },
-], Total: 20.18356164383562 } }
+], Total: 21.545205479452058 } }
 
 results[4] = { Date: 2014-01-01T00:00:00, ManifestSHA: 4d02b2e0fd6c71526408396d9614e015f4c47b5f, LibYear: { _packagesValues: [
 { Name: "actionmailer", RepoVersion: "4.0.2", RepoVersionPublishedAt: 2013-12-03T00:00:00, LatestVersion: "4.0.2", LatestPublishedAt: 2013-12-03T00:00:00, UpgradeAvailable: False, Value: 0 },
@@ -7628,7 +7632,15 @@ results[47] = { Date: 2017-08-01T00:00:00, ManifestSHA: 0bbccf3f510a16f847b2a419
 
 results[48] = { Date: 2017-09-01T00:00:00, ManifestSHA: 9a934fe16e1b686b7f24ee101cc4e9d28cce2ae5, LibYear: { _packagesValues: [
 { Name: "CFPropertyList", RepoVersion: "2.3.5", RepoVersionPublishedAt: 2017-01-27T00:00:00, LatestVersion: "2.3.5", LatestPublishedAt: 2017-01-27T00:00:00, UpgradeAvailable: False, Value: 0 },
+{ Name: "actioncable", RepoVersion: "5.1.4.rc1", RepoVersionPublishedAt: 2017-08-24T00:00:00, LatestVersion: "5.1.4.rc1", LatestPublishedAt: 2017-08-24T00:00:00, UpgradeAvailable: False, Value: 0 },
+{ Name: "actionmailer", RepoVersion: "5.1.4.rc1", RepoVersionPublishedAt: 2017-08-24T00:00:00, LatestVersion: "5.1.4.rc1", LatestPublishedAt: 2017-08-24T00:00:00, UpgradeAvailable: False, Value: 0 },
+{ Name: "actionpack", RepoVersion: "5.1.4.rc1", RepoVersionPublishedAt: 2017-08-24T00:00:00, LatestVersion: "5.1.4.rc1", LatestPublishedAt: 2017-08-24T00:00:00, UpgradeAvailable: False, Value: 0 },
+{ Name: "actionview", RepoVersion: "5.1.4.rc1", RepoVersionPublishedAt: 2017-08-24T00:00:00, LatestVersion: "5.1.4.rc1", LatestPublishedAt: 2017-08-24T00:00:00, UpgradeAvailable: False, Value: 0 },
+{ Name: "activejob", RepoVersion: "5.1.4.rc1", RepoVersionPublishedAt: 2017-08-24T00:00:00, LatestVersion: "5.1.4.rc1", LatestPublishedAt: 2017-08-24T00:00:00, UpgradeAvailable: False, Value: 0 },
+{ Name: "activemodel", RepoVersion: "5.1.4.rc1", RepoVersionPublishedAt: 2017-08-24T00:00:00, LatestVersion: "5.1.4.rc1", LatestPublishedAt: 2017-08-24T00:00:00, UpgradeAvailable: False, Value: 0 },
+{ Name: "activerecord", RepoVersion: "5.1.4.rc1", RepoVersionPublishedAt: 2017-08-24T00:00:00, LatestVersion: "5.1.4.rc1", LatestPublishedAt: 2017-08-24T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "activerecord-import", RepoVersion: "0.19.1", RepoVersionPublishedAt: 2017-07-20T00:00:00, LatestVersion: "0.19.1", LatestPublishedAt: 2017-07-20T00:00:00, UpgradeAvailable: False, Value: 0 },
+{ Name: "activesupport", RepoVersion: "5.1.4.rc1", RepoVersionPublishedAt: 2017-08-24T00:00:00, LatestVersion: "5.1.4.rc1", LatestPublishedAt: 2017-08-24T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "addressable", RepoVersion: "2.5.2", RepoVersionPublishedAt: 2017-08-25T00:00:00, LatestVersion: "2.5.2", LatestPublishedAt: 2017-08-25T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "aggregate", RepoVersion: "0.2.2", RepoVersionPublishedAt: 2011-03-05T00:00:00, LatestVersion: "0.2.2", LatestPublishedAt: 2011-03-05T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "apnotic", RepoVersion: "1.1.0", RepoVersionPublishedAt: 2017-03-01T00:00:00, LatestVersion: "1.1.0", LatestPublishedAt: 2017-03-01T00:00:00, UpgradeAvailable: False, Value: 0 },
@@ -7762,11 +7774,13 @@ results[48] = { Date: 2017-09-01T00:00:00, ManifestSHA: 9a934fe16e1b686b7f24ee10
 { Name: "rack", RepoVersion: "2.0.3", RepoVersionPublishedAt: 2017-05-15T00:00:00, LatestVersion: "2.0.3", LatestPublishedAt: 2017-05-15T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "rack-protection", RepoVersion: "2.0.0", RepoVersionPublishedAt: 2017-05-07T00:00:00, LatestVersion: "2.0.0", LatestPublishedAt: 2017-05-07T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "rack-test", RepoVersion: "0.7.0", RepoVersionPublishedAt: 2017-07-10T00:00:00, LatestVersion: "0.7.0", LatestPublishedAt: 2017-07-10T00:00:00, UpgradeAvailable: False, Value: 0 },
+{ Name: "rails", RepoVersion: "5.1.4.rc1", RepoVersionPublishedAt: 2017-08-24T00:00:00, LatestVersion: "5.1.4.rc1", LatestPublishedAt: 2017-08-24T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "rails-controller-testing", RepoVersion: "1.0.2", RepoVersionPublishedAt: 2017-05-17T00:00:00, LatestVersion: "1.0.2", LatestPublishedAt: 2017-05-17T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "rails-deprecated_sanitizer", RepoVersion: "1.0.3", RepoVersionPublishedAt: 2014-09-25T00:00:00, LatestVersion: "1.0.3", LatestPublishedAt: 2014-09-25T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "rails-dom-testing", RepoVersion: "2.0.3", RepoVersionPublishedAt: 2017-05-10T00:00:00, LatestVersion: "2.0.3", LatestPublishedAt: 2017-05-10T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "rails-html-sanitizer", RepoVersion: "1.0.3", RepoVersionPublishedAt: 2016-01-25T00:00:00, LatestVersion: "1.0.3", LatestPublishedAt: 2016-01-25T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "rails_autolink", RepoVersion: "1.1.6", RepoVersionPublishedAt: 2014-06-08T00:00:00, LatestVersion: "1.1.6", LatestPublishedAt: 2014-06-08T00:00:00, UpgradeAvailable: False, Value: 0 },
+{ Name: "railties", RepoVersion: "5.1.4.rc1", RepoVersionPublishedAt: 2017-08-24T00:00:00, LatestVersion: "5.1.4.rc1", LatestPublishedAt: 2017-08-24T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "raindrops", RepoVersion: "0.19.0", RepoVersionPublishedAt: 2017-08-09T00:00:00, LatestVersion: "0.19.0", LatestPublishedAt: 2017-08-09T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "rake", RepoVersion: "12.0.0", RepoVersionPublishedAt: 2016-12-06T00:00:00, LatestVersion: "12.0.0", LatestPublishedAt: 2016-12-06T00:00:00, UpgradeAvailable: False, Value: 0 },
 { Name: "rb-fsevent", RepoVersion: "0.10.2", RepoVersionPublishedAt: 2017-07-01T00:00:00, LatestVersion: "0.10.2", LatestPublishedAt: 2017-07-01T00:00:00, UpgradeAvailable: False, Value: 0 },

--- a/Freshli.Test/Integration/Languages/Perl/MetaCpanRepositoryTest.cs
+++ b/Freshli.Test/Integration/Languages/Perl/MetaCpanRepositoryTest.cs
@@ -30,7 +30,8 @@ namespace Freshli.Test.Integration.Languages.Perl {
     public void LatestAsOf() {
       var repository = new MetaCpanRepository();
       var targetDate = new DateTime(2018, 01, 01, 0, 0, 0, DateTimeKind.Utc);
-      var versionInfo = repository.Latest("Plack", targetDate);
+      var versionInfo = repository.Latest(
+        "Plack", targetDate, includePreReleases: false);
       var expectedDate = new DateTime(
         2017,
         12,
@@ -99,7 +100,7 @@ namespace Freshli.Test.Integration.Languages.Perl {
       var laterVersion = new SemVerVersionInfo {Version = "1.0045"};
 
       var versions = repository.VersionsBetween("Plack", targetDate,
-        earlierVersion, laterVersion);
+        earlierVersion, laterVersion, includePreReleases: false);
 
       Assert.Equal(6, versions.Count);
     }

--- a/Freshli.Test/Integration/Languages/Php/PackagistRepositoryTest.cs
+++ b/Freshli.Test/Integration/Languages/Php/PackagistRepositoryTest.cs
@@ -27,7 +27,7 @@ namespace Freshli.Test.Integration {
       );
       var versionInfo = repository.Latest(
         "monolog/monolog",
-        new DateTime(2020, 01, 01)
+        new DateTime(2020, 01, 01), includePreReleases: false
       );
 
       Assert.Equal("2.0.2", versionInfo.Version);
@@ -44,7 +44,7 @@ namespace Freshli.Test.Integration {
 
       var versionInfo = repository.Latest(
         "symfony/css-selector",
-        new DateTime(2020, 01, 01)
+        new DateTime(2020, 01, 01), includePreReleases: false
       );
 
       Assert.Equal("v5.0.2", versionInfo.Version);

--- a/Freshli.Test/Integration/Languages/Python/PyPIRepositoryTest.cs
+++ b/Freshli.Test/Integration/Languages/Python/PyPIRepositoryTest.cs
@@ -26,7 +26,8 @@ namespace Freshli.Test.Integration.Languages.Python {
     public void LatestAsOf() {
       var repository = new PyPIRepository();
       var targetDate = new DateTime(2020, 01, 01, 0, 0, 0, DateTimeKind.Utc);
-      var versionInfo = repository.Latest("numpy", targetDate);
+      var versionInfo = repository.Latest(
+        "numpy", targetDate, includePreReleases: false);
       var expectedDate = new DateTime(
         2019,
         12,
@@ -45,14 +46,6 @@ namespace Freshli.Test.Integration.Languages.Python {
     [InlineData("numpy", "==1.16.*", 2019, 12, 29, 22, 23, 23, "1.16.6")]
     [InlineData("matplotlib", "==3.*", 2019, 11, 21, 22, 51, 38, "3.1.2")]
     [InlineData("seaborn", "==0.8.1", 2017, 09, 03, 16, 38, 23, "0.8.1")]
-    // six>=1.5
-    // kiwisolver>1.0.1
-    // pandas
-    // pytz>=2017.2,<2020.1
-    // scipy<1.4.1
-    // seaborn<=0.8.1
-    // numpy!=1.16.*
-    // numpy!=1.16.6
     public void VersionExpressionMatching(
       string packageName,
       string versionExpression,
@@ -94,7 +87,7 @@ namespace Freshli.Test.Integration.Languages.Python {
     var laterVersion = new SemVerVersionInfo {Version = "3.0.3"};
 
     var versions = repository.VersionsBetween("pymongo", targetDate,
-      earlierVersion, laterVersion);
+      earlierVersion, laterVersion, includePreReleases: false);
 
     Assert.Equal(4, versions.Count);
     }

--- a/Freshli.Test/Integration/Languages/Ruby/RubyGemsRepositoryTest.cs
+++ b/Freshli.Test/Integration/Languages/Ruby/RubyGemsRepositoryTest.cs
@@ -6,7 +6,7 @@ namespace Freshli.Test.Integration.Languages.Ruby {
   public class RubyGemsRepositoryTest {
 
     [Fact]
-    public void VersionInfo() {
+    public void VersionInfoCorrectlyCreatesVersion() {
       var repository = new RubyGemsRepository();
       var versionInfo = repository.VersionInfo("tzinfo", "1.2.7");
       var expectedDate = new DateTime(2020, 04, 02);
@@ -15,29 +15,77 @@ namespace Freshli.Test.Integration.Languages.Ruby {
       Assert.Equal(expectedDate, versionInfo.DatePublished);
     }
 
-      [Fact]
-      public void LatestAsOf() {
-        var repository = new RubyGemsRepository();
-        var targetDate = new DateTime(2020, 01, 01);
-        var versionInfo = repository.Latest("tzinfo", targetDate);
-        var expectedDate = new DateTime(2019, 12, 24);
+    [Fact]
+    public void VersionInfoCorrectlyCreatesPreReleaseVersion() {
+      var repository = new RubyGemsRepository();
+      var versionInfo = repository.VersionInfo("git", "1.6.0.pre1");
+      var expectedDate = new DateTime(2020, 01, 20);
 
-        Assert.Equal("2.0.1", versionInfo.Version);
-        Assert.Equal(expectedDate, versionInfo.DatePublished);
-      }
+      Assert.Equal("1.6.0.pre1", versionInfo.Version);
+      Assert.Equal(expectedDate, versionInfo.DatePublished);
+    }
 
     [Fact]
-    public void VersionsBetween() {
+    public void LatestAsOfCorrectlyFindsLatestVersion() {
+      var repository = new RubyGemsRepository();
+      var targetDate = new DateTime(2020, 02, 01);
+      var versionInfo = repository.Latest("git", targetDate, false);
+      var expectedDate = new DateTime(2018, 08, 10);
+
+      Assert.Equal("1.5.0", versionInfo.Version);
+      Assert.Equal(expectedDate, versionInfo.DatePublished);
+    }
+
+    [Fact]
+    public void
+      LatestAsOfCorrectlyFindsLatestPreReleaseVersion() {
+      var repository = new RubyGemsRepository();
+      var targetDate = new DateTime(2020, 02, 01);
+      var versionInfo = repository.Latest("git", targetDate, true);
+      var expectedDate = new DateTime(2020, 01, 20);
+
+      Assert.Equal("1.6.0.pre1", versionInfo.Version);
+      Assert.Equal(expectedDate, versionInfo.DatePublished);
+    }
+
+    [Fact]
+    public void VersionsBetweenFindsVersionsReleasedBeforeTargetDate() {
     var repository = new RubyGemsRepository();
     var targetDate = new DateTime(2014, 04, 01);
     var earlierVersion = new RubyGemsVersionInfo {Version = "0.3.38"};
     var laterVersion = new RubyGemsVersionInfo {Version = "1.1.0"};
 
     var versions = repository.VersionsBetween("tzinfo", targetDate,
-      earlierVersion, laterVersion);
+      earlierVersion, laterVersion, includePreReleases: true);
 
     Assert.Equal(3, versions.Count);
     }
-  }
 
+    [Fact]
+    public void VersionsBetweenCorrectlyFindsVersions() {
+      var repository = new RubyGemsRepository();
+      var targetDate = new DateTime(2020, 09, 01);
+      var earlierVersion = new RubyGemsVersionInfo {Version = "3.11.0"};
+      var laterVersion = new RubyGemsVersionInfo {Version = "3.13.0"};
+
+      var versions = repository.VersionsBetween(name: "google-protobuf",
+        targetDate, earlierVersion, laterVersion, includePreReleases: false);
+
+      Assert.Equal(8, versions.Count);
+    }
+
+
+    [Fact]
+    public void VersionsBetweenCorrectlyFindsVersionsWithPreReleases() {
+      var repository = new RubyGemsRepository();
+      var targetDate = new DateTime(2020, 09, 01);
+      var earlierVersion = new RubyGemsVersionInfo {Version = "3.11.0"};
+      var laterVersion = new RubyGemsVersionInfo {Version = "3.13.0"};
+
+      var versions = repository.VersionsBetween(name: "google-protobuf",
+        targetDate, earlierVersion, laterVersion, includePreReleases: true);
+
+      Assert.Equal(11, versions.Count);
+    }
+  }
 }

--- a/Freshli.Test/Integration/LibYearCalculatorTest.cs
+++ b/Freshli.Test/Integration/LibYearCalculatorTest.cs
@@ -139,13 +139,59 @@ namespace Freshli.Test.Integration {
     }
 
     [Fact]
+    public void ComputeAsOfWithPreReleaseVersion() {
+      var manifest = new BundlerManifest();
+      manifest.Add("google-protobuf", "3.12.0.rc.1");
+      var repository = new RubyGemsRepository();
+      var calculator = new LibYearCalculator(repository, manifest);
+
+      var results = calculator.ComputeAsOf(new DateTime(2020, 06, 01));
+
+      Assert.Equal(0.063, results.Total, 3);
+      Assert.Equal(0.063, results["google-protobuf"].Value, 3);
+      Assert.Equal("3.12.0.rc.1", results["google-protobuf"].Version);
+      Assert.Equal(
+        new DateTime(2020, 05, 04),
+        results["google-protobuf"].PublishedAt
+      );
+      Assert.Equal("3.12.2", results["google-protobuf"].LatestVersion);
+      Assert.Equal(
+        new DateTime(2020, 05, 27),
+        results["google-protobuf"].LatestPublishedAt
+      );
+      Assert.True(results["google-protobuf"].UpgradeAvailable);
+    }
+
+    [Fact]
+    public void ComputeAsOfWithLatestVersionBeingPreReleaseVersion() {
+      var manifest = new BundlerManifest();
+      manifest.Add("google-protobuf", "3.10.0.rc.1");
+      var repository = new RubyGemsRepository();
+      var calculator = new LibYearCalculator(repository, manifest);
+
+      var results = calculator.ComputeAsOf(new DateTime(2019, 11, 25));
+
+      Assert.Equal(0.216, results.Total, 3);
+      Assert.Equal(0.216, results["google-protobuf"].Value, 3);
+      Assert.Equal("3.10.0.rc.1", results["google-protobuf"].Version);
+      Assert.Equal(
+        new DateTime(2019, 09, 05),
+        results["google-protobuf"].PublishedAt
+      );
+      Assert.Equal("3.11.0.rc.2", results["google-protobuf"].LatestVersion);
+      Assert.Equal(
+        new DateTime(2019, 11, 23),
+        results["google-protobuf"].LatestPublishedAt
+      );
+      Assert.True(results["google-protobuf"].UpgradeAvailable);
+    }
+
+    [Fact]
     public void Compute() {
       var olderVersion = new SemVerVersionInfo("1.7.0",
         new DateTime(2016, 12, 27));
       var newerVersion = new SemVerVersionInfo("1.7.1",
         new DateTime(2017, 03, 20));
-
-      var calculator = new LibYearCalculator(null, null);
 
       Assert.Equal(
         0.227,

--- a/Freshli.Test/Unit/SemVerVersionInfoTest.cs
+++ b/Freshli.Test/Unit/SemVerVersionInfoTest.cs
@@ -4,38 +4,40 @@ using Xunit;
 namespace Freshli.Test.Unit {
   public class SemVerVersionInfoTest {
     [Theory]
-    [InlineData("1", 1, null, null, null, null)]
-    [InlineData("v3.6.0", 3, 6, 0, null, null)]
-    [InlineData("1.2", 1, 2, null, null, null)]
-    [InlineData("1.2.3", 1, 2, 3, null, null)]
-    [InlineData("1.2.3a1", 1, 2, 3, "a1", null)]
-    [InlineData("1.2.3-a1", 1, 2, 3, "a1", null)]
-    [InlineData("1.2.3a1+dev", 1, 2, 3, "a1", "dev")]
-    [InlineData("1.2.3-a1+dev", 1, 2, 3, "a1", "dev")]
-    [InlineData("1.0045", 1, 0045, null, null, null)]
-    [InlineData("1.0009", 1, 0009, null, null, null)]
-    [InlineData("1.301001_050", 1, 301001, 050, null, null)]
-    [InlineData("20110131120940", 20110131120940, null, null, null, null)]
-    [InlineData("2.20110131120940", 2, 20110131120940, null, null, null)]
-    [InlineData("2.0.20110131120940", 2, 0, 20110131120940, null, null)]
-    [InlineData("2.0.8.beta.20110131120940", 2, 0, 8, "beta.20110131120940",
+    [InlineData("1", 1, null, null, false, null, null)]
+    [InlineData("v3.6.0", 3, 6, 0, false, null, null)]
+    [InlineData("1.2", 1, 2, null, false, null, null)]
+    [InlineData("1.2.3", 1, 2, 3, false, null, null)]
+    [InlineData("1.2.3a1", 1, 2, 3, true, "a1", null)]
+    [InlineData("1.2.3-a1", 1, 2, 3, true, "a1", null)]
+    [InlineData("1.2.3a1+dev", 1, 2, 3, true, "a1", "dev")]
+    [InlineData("1.2.3-a1+dev", 1, 2, 3, true, "a1", "dev")]
+    [InlineData("1.0045", 1, 0045, null, false, null, null)]
+    [InlineData("1.0009", 1, 0009, null, false, null, null)]
+    [InlineData("1.301001_050", 1, 301001, 050, false, null, null)]
+    [InlineData("20110131120940", 20110131120940, null, null, false, null,
       null)]
-    [InlineData("1.0.0-alpha", 1, 0, 0, "alpha", null)]
-    [InlineData("1.0.0-alpha.1", 1, 0, 0, "alpha.1", null)]
-    [InlineData("1.0.0-0.3.7", 1, 0, 0, "0.3.7", null)]
-    [InlineData("1.0.0-x.7.z.92", 1, 0, 0, "x.7.z.92", null)]
-    [InlineData("1.0.0-x-y-z.-", 1, 0, 0, "x-y-z.-", null)]
-    [InlineData("1.0.0-alpha+001", 1, 0, 0, "alpha", "001")]
-    [InlineData("1.0.0+20130313144700", 1, 0, 0, null, "20130313144700")]
-    [InlineData("1.0.0-beta+exp.sha.5114f85", 1, 0, 0, "beta",
+    [InlineData("2.20110131120940", 2, 20110131120940, null, false, null, null)]
+    [InlineData("2.0.20110131120940", 2, 0, 20110131120940, false, null, null)]
+    [InlineData("2.0.8.beta.20110131120940", 2, 0, 8, true,
+      "beta.20110131120940", null)]
+    [InlineData("1.0.0-alpha", 1, 0, 0, true, "alpha", null)]
+    [InlineData("1.0.0-alpha.1", 1, 0, 0, true, "alpha.1", null)]
+    [InlineData("1.0.0-0.3.7", 1, 0, 0, true, "0.3.7", null)]
+    [InlineData("1.0.0-x.7.z.92", 1, 0, 0, true, "x.7.z.92", null)]
+    [InlineData("1.0.0-x-y-z.-", 1, 0, 0, true, "x-y-z.-", null)]
+    [InlineData("1.0.0-alpha+001", 1, 0, 0, true, "alpha", "001")]
+    [InlineData("1.0.0+20130313144700", 1, 0, 0, false, null, "20130313144700")]
+    [InlineData("1.0.0-beta+exp.sha.5114f85", 1, 0, 0, true, "beta",
       "exp.sha.5114f85")]
-    [InlineData("1.0.0+21AF26D3--117B344092BD", 1, 0, 0, null,
+    [InlineData("1.0.0+21AF26D3--117B344092BD", 1, 0, 0, false, null,
       "21AF26D3--117B344092BD")]
     public void VersionIsParsedIntoParts(
       string version,
       long? major,
       long? minor,
       long? patch,
+      bool isPreRelease,
       string preRelease,
       string buildMetadata
     ) {
@@ -43,6 +45,7 @@ namespace Freshli.Test.Unit {
       Assert.Equal(major, info.Major);
       Assert.Equal(minor, info.Minor);
       Assert.Equal(patch, info.Patch);
+      Assert.Equal(isPreRelease, info.IsPreRelease);
       Assert.Equal(preRelease, info.PreRelease);
       Assert.Equal(buildMetadata, info.BuildMetadata);
     }

--- a/Freshli/Exceptions/VersionNotFoundException.cs
+++ b/Freshli/Exceptions/VersionNotFoundException.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Freshli.Exceptions {
+  public class VersionNotFoundException : Exception {
+
+    public VersionNotFoundException(string dependency, string version,
+      Exception e)
+      : base($"Unable to find {version} version of " +
+        $"{dependency}.", e)
+    {
+    }
+
+  }
+}

--- a/Freshli/IPackageRepository.cs
+++ b/Freshli/IPackageRepository.cs
@@ -4,13 +4,14 @@ using System.Collections.Generic;
 namespace Freshli {
   public interface IPackageRepository {
     IVersionInfo VersionInfo(string name, string version);
-    IVersionInfo Latest(string name, DateTime asOf);
+    IVersionInfo Latest(string name, DateTime asOf, bool includePreReleases);
     IVersionInfo Latest(string name, DateTime asOf, string thatMatches);
     List<IVersionInfo> VersionsBetween(
       string name,
       DateTime asOf,
       IVersionInfo earlierVersion,
-      IVersionInfo laterVersion
+      IVersionInfo laterVersion,
+      bool includePreReleases
     );
   }
 }

--- a/Freshli/IVersionInfo.cs
+++ b/Freshli/IVersionInfo.cs
@@ -7,6 +7,8 @@ namespace Freshli {
 
     public DateTime DatePublished { get; set; }
 
+    public bool IsPreRelease { get; set; }
+
     public string ToSimpleVersion();
 
   }

--- a/Freshli/Languages/Perl/MetaCpanRepository.cs
+++ b/Freshli/Languages/Perl/MetaCpanRepository.cs
@@ -61,7 +61,12 @@ namespace Freshli.Languages.Perl {
       return versions;
     }
 
-    public IVersionInfo Latest(string name, DateTime asOf) {
+    //TODO: Update logic to utilize includePreReleases
+    public IVersionInfo Latest(
+      string name,
+      DateTime asOf,
+      bool includePreReleases)
+    {
       return GetReleaseHistory(name).OrderByDescending(v => v).
         First(v => asOf >= v.DatePublished);
     }
@@ -77,8 +82,10 @@ namespace Freshli.Languages.Perl {
         First(v => expression.DoesMatch(v));
     }
 
+    //TODO: Update logic to utilize includePreReleases
     public List<IVersionInfo> VersionsBetween(string name, DateTime asOf,
-      IVersionInfo earlierVersion, IVersionInfo laterVersion)
+      IVersionInfo earlierVersion, IVersionInfo laterVersion,
+      bool includePreReleases)
     {
       try {
         return GetReleaseHistory(name).

--- a/Freshli/Languages/Php/ComposerRepository.cs
+++ b/Freshli/Languages/Php/ComposerRepository.cs
@@ -19,7 +19,12 @@ namespace Freshli.Languages.Php {
       _baseUrl = baseUrl;
     }
 
-    public IVersionInfo Latest(string name, DateTime asOf) {
+    //TODO: Update logic to utilize includePreReleases
+    public IVersionInfo Latest(
+      string name,
+      DateTime asOf,
+      bool includePreReleases)
+    {
       var content = FetchPackageInfo(name);
       if (content == null) return null;
 
@@ -108,8 +113,12 @@ namespace Freshli.Languages.Php {
       throw new NotImplementedException();
     }
 
-    public List<IVersionInfo> VersionsBetween(string name, DateTime asOf,
-      IVersionInfo earlierVersion, IVersionInfo laterVersion)
+    public List<IVersionInfo> VersionsBetween(
+      string name,
+      DateTime asOf,
+      IVersionInfo earlierVersion,
+      IVersionInfo laterVersion,
+      bool includePreReleases)
     {
       //TODO: Implement method
       throw new NotImplementedException();

--- a/Freshli/Languages/Php/MulticastComposerRepository.cs
+++ b/Freshli/Languages/Php/MulticastComposerRepository.cs
@@ -40,9 +40,13 @@ namespace Freshli.Languages.Php {
       }
     }
 
-    public IVersionInfo Latest(string name, DateTime asOf) {
+    public IVersionInfo Latest(
+      string name,
+      DateTime asOf,
+      bool includePreReleases)
+    {
       foreach (var repository in _composerRespositories) {
-        var result = repository.Latest(name, asOf);
+        var result = repository.Latest(name, asOf, includePreReleases);
         if (result != null) {
           return result;
         }
@@ -66,8 +70,12 @@ namespace Freshli.Languages.Php {
       throw new NotImplementedException();
     }
 
-    public List<IVersionInfo> VersionsBetween(string name, DateTime asOf,
-      IVersionInfo earlierVersion, IVersionInfo laterVersion)
+    public List<IVersionInfo> VersionsBetween(
+      string name,
+      DateTime asOf,
+      IVersionInfo earlierVersion,
+      IVersionInfo laterVersion,
+      bool includePreReleases)
     {
       //TODO: Implement method
       throw new NotImplementedException();

--- a/Freshli/Languages/Python/PyPIRepository.cs
+++ b/Freshli/Languages/Python/PyPIRepository.cs
@@ -54,7 +54,12 @@ namespace Freshli.Languages.Python {
       }
     }
 
-    public IVersionInfo Latest(string name, DateTime asOf) {
+    //TODO: Update logic to utilize includePreReleases
+    public IVersionInfo Latest(
+      string name,
+      DateTime asOf,
+      bool includePreReleases)
+    {
       try {
         return GetReleaseHistory(name).OrderByDescending(v => v).
           First(v => asOf >= v.DatePublished);
@@ -87,8 +92,13 @@ namespace Freshli.Languages.Python {
       }
     }
 
-    public List<IVersionInfo> VersionsBetween(string name, DateTime asOf,
-      IVersionInfo earlierVersion, IVersionInfo laterVersion)
+    //TODO: Update logic to utilize includePreReleases
+    public List<IVersionInfo> VersionsBetween(
+      string name,
+      DateTime asOf,
+      IVersionInfo earlierVersion,
+      IVersionInfo laterVersion,
+      bool includePreReleases)
     {
       try {
         return GetReleaseHistory(name).

--- a/Freshli/Languages/Ruby/RubyGemsVersionInfo.cs
+++ b/Freshli/Languages/Ruby/RubyGemsVersionInfo.cs
@@ -23,7 +23,7 @@ namespace Freshli.Languages.Ruby {
 
     public DateTime DatePublished { get; set; }
 
-    public bool IsPreRelease { get; private set; }
+    public bool IsPreRelease { get; set; }
 
     public List<string> VersionParts { get; private set; }
 

--- a/Freshli/LibYearCalculator.cs
+++ b/Freshli/LibYearCalculator.cs
@@ -23,8 +23,6 @@ namespace Freshli {
         IVersionInfo currentVersion;
 
         try {
-          latestVersion = Repository.Latest(package.Name, date);
-
           if (Manifest.UsesExactMatches) {
             currentVersion =
               Repository.VersionInfo(package.Name, package.Version);
@@ -35,6 +33,8 @@ namespace Freshli {
               thatMatches: package.Version
             );
           }
+          latestVersion =
+            Repository.Latest(package.Name, date, currentVersion.IsPreRelease);
         }
         catch (Exception e) {
           _logger.Warn($"Skipping {package.Name}: {e.Message}");
@@ -110,7 +110,8 @@ namespace Freshli {
           name,
           asOf,
           currentVersion,
-          latestVersion
+          latestVersion,
+          currentVersion.IsPreRelease
         )) {
           var value = Compute(currentVersion, version);
           if (value >= 0) {

--- a/Freshli/Runner.cs
+++ b/Freshli/Runner.cs
@@ -78,7 +78,7 @@ namespace Freshli {
       }
       var dateTime = DateTime.Now;
       var filePath =
-        $"{ResultsPath}/{dateTime:yyyy-MM-dd-ssfffffff}-results.txt";
+        $"{ResultsPath}/{dateTime:yyyy-MM-dd-hhmmssfffffff}-results.txt";
       using var file = new System.IO.StreamWriter(filePath);
       foreach (var result in results) {
         file.WriteLine(result);

--- a/Freshli/Runner.cs
+++ b/Freshli/Runner.cs
@@ -4,6 +4,12 @@ using NLog;
 
 namespace Freshli {
   public class Runner {
+
+    private static readonly string SaveResultsToFile =
+      Environment.GetEnvironmentVariable("SAVE_RESULTS_TO_FILE") ?? "false";
+
+    private const string ResultsPath = "results";
+
     private static readonly Logger logger = LogManager.GetCurrentClassLogger();
 
     public ManifestFinder ManifestFinder { get; private set; }
@@ -55,11 +61,29 @@ namespace Freshli {
         logger.Warn("Unable to find a manifest file");
       }
 
+      if (SaveResultsToFile.ToLower() == "true") {
+        WriteResultsToFile(metricsResults);
+      }
+
       return metricsResults;
     }
 
     public IList<MetricsResult> Run(string analysisPath) {
       return Run(analysisPath, asOf: DateTime.Today);
     }
+
+    private static void WriteResultsToFile(List<MetricsResult> results) {
+      if (!System.IO.Directory.Exists(ResultsPath)) {
+        System.IO.Directory.CreateDirectory(ResultsPath);
+      }
+      var dateTime = DateTime.Now;
+      var filePath =
+        $"{ResultsPath}/{dateTime:yyyy-MM-dd-ssfffffff}-results.txt";
+      using var file = new System.IO.StreamWriter(filePath);
+      foreach (var result in results) {
+        file.WriteLine(result);
+      }
+    }
+
   }
 }

--- a/Freshli/SemVerVersionInfo.cs
+++ b/Freshli/SemVerVersionInfo.cs
@@ -31,6 +31,7 @@ namespace Freshli {
       }
     }
 
+    public bool IsPreRelease { get; set; }
     public string PreReleaseLabel { get; private set; }
     public long? PreReleaseIncrement { get; private set; }
     public string BuildMetadata { get; private set; }
@@ -50,6 +51,7 @@ namespace Freshli {
 
     private void ParsePreRelease(string value) {
       if (!String.IsNullOrEmpty(value)) {
+        IsPreRelease = true;
         var match = _preReleaseExpression.Match(value);
         PreReleaseLabel = match.Groups[1].Value;
         var incrementValue = match.Groups[2].Value;
@@ -57,6 +59,7 @@ namespace Freshli {
           PreReleaseIncrement = Convert.ToInt64(incrementValue);
         }
       } else {
+        IsPreRelease = false;
         PreReleaseLabel = null;
         PreReleaseIncrement = null;
       }


### PR DESCRIPTION
Per #153, updates logic to include Ruby pre-release dependency versions if the manifest version is a pre-release version.

This PR only updates the logic for Ruby. Other supported languages will need to be updated if/when issues arise. 

Additionally, a configurable option to output the results to a local file was added.