### PR TITLE
Fix eclint error

### DIFF
--- a/Freshli/Languages/Python/Conversions.cs
+++ b/Freshli/Languages/Python/Conversions.cs
@@ -26,7 +26,8 @@ namespace Freshli.Languages.Python {
 
     public static long[] SafeSplitIntoLongs(string value, char separator) {
       if (!string.IsNullOrWhiteSpace(value)) {
-        return value.Split(separator).Select(p => Convert.ToInt64((string?) p)).ToArray();
+        return value.Split(separator).Select(p => Convert.ToInt64((string?) p)).
+          ToArray();
       }
       return new long[] {};
     }


### PR DESCRIPTION
Fixes the outstanding eclint error by adding a line break to a line that was too long.