### PR TITLE
Fixed dependency for Ubuntu 20LTS environment

### DIFF
--- a/Freshli/Freshli.csproj
+++ b/Freshli/Freshli.csproj
@@ -12,7 +12,7 @@
       <PackageReference Include="DotNetEnv" Version="2.0.0" />
       <PackageReference Include="Elasticsearch.Net" Version="7.10.1" />
       <PackageReference Include="HtmlAgilityPack" Version="1.11.29" />
-      <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
+      <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0096" />
       <PackageReference Include="NLog" Version="4.7.6" />
       <PackageReference Include="RestSharp" Version="106.11.7" />
     </ItemGroup>


### PR DESCRIPTION
This fixes the dependency necessary to enable development in a Ubuntu 20.04LTS environment as detailed in issue #206.

The updates enclosed include an update to the .NET core SDK minor version and an update to the package version of LibGit2Sharp.

As of these updates, Freshli successfully builds, runs, and passes the testing suite on Ubuntu 20.04; however, I am concerned about how this might affect the other operating systems and would be grateful if someone could ensure that these changes don't negatively affect development on Mac or Windows. If there are any other necessary changes needed, then I will definitely be willing to work for a different resolution! 😄

Associated Commit: https://github.com/corgibytes/freshli/commit/df6a532ca4207b893187fa52cece76975aef4b6b
