### PR TITLE
Migrates to .NET 5.0

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.301
+        dotnet-version: 5.0.101
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/Freshli.Test/Acceptance.cs
+++ b/Freshli.Test/Acceptance.cs
@@ -116,7 +116,7 @@ namespace Freshli.Test {
       var runner = new Runner();
 
       var results = runner.Run(
-        "https://github.com/gocd/gocd",
+        "https://github.com/gohugoio/hugo",
         asOf: _testingBoundary
       );
 

--- a/Freshli.Test/Freshli.Test.csproj
+++ b/Freshli.Test/Freshli.Test.csproj
@@ -1,9 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
+
+        <LangVersion>9</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Freshli/Freshli.csproj
+++ b/Freshli/Freshli.csproj
@@ -2,9 +2,10 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
         <VersionPrefix>1.0.0</VersionPrefix>
         <VersionSuffix>dev-$([System.DateTime]::Now.ToString("yyyyMMddTHHmm"))</VersionSuffix>
+        <LangVersion>9</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.301"
+    "version": "5.0.101",
+    "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
This should address the goals of  #193 (Change build target to .NET 5.0).

This also sets the `rollForward` setting in `global.json` to `latestMinor`. That way, it should make it easier for people who are trying to build the project using slightly newer, but still very likely compatible, versions of the .NET SDK.