### PR TITLE
Enables Nullability for PythonVersionInfo

### DIFF
--- a/Freshli/Languages/Python/Conversions.cs
+++ b/Freshli/Languages/Python/Conversions.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Linq;
 
 namespace Freshli.Languages.Python {
@@ -16,7 +17,7 @@ namespace Freshli.Languages.Python {
       return value != null;
     }
 
-    public static string SafeToLower(string value) {
+    public static string? SafeToLower(string value) {
       if (!string.IsNullOrWhiteSpace(value)) {
         return value.ToLower();
       }
@@ -32,7 +33,7 @@ namespace Freshli.Languages.Python {
       return new long[] {};
     }
 
-    public static string SafeExtractString(string value) {
+    public static string? SafeExtractString(string value) {
       if (!string.IsNullOrWhiteSpace(value)) {
         return value;
       }


### PR DESCRIPTION
### Summary
This change annotates the PythonVersionInfo class to enable nullable references. This clears the warning and indicates intent to work with nullable references. 

### Details
C# 8.0 added the nullable annotation to allow for fine-grain control on the nullability of references. This annotation also allows for the change to the SafeToLower and SafeExtract methods, that can potentially return null, to return Nullable strings which further enables null-safe checking.

More information is available [Microsoft's Nullable documentation.](https://docs.microsoft.com/en-us/dotnet/csharp/nullable-references#nullable-annotation-context)

### Solution
Enabling this annotation and adding the nullable `?` to the `string` return types of SafeToLower and SafeExtract eliminated that warnings in the build and should help future development use these methods with care.
If there is anything else that I did not take into account, please let me know! I'd be more than happy to make those changes.

Resolves #199