### PR TITLE
Adds .NET Core SDK download link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Freshli reads source code repository history to access previous version of each 
 
 ### Running `freshli`
 
-Right now to run `freshli` from the command line, you need to have the .NET Core SDK installed.
+Right now to run `freshli` from the command line, you need to have the [.NET Core SDK](https://dotnet.microsoft.com/download/dotnet-core) installed.
 
 Once you do, you can run use `dotnet run --project Freshli/Freshli.csproj -- <url>` to run the project.
 


### PR DESCRIPTION
While reading through the documentation, I had to go through and update my copy of .NET Core SDK. Thinking it'll be useful to have the link to download the latest version of the SDK available right in the documentation.