### PR TITLE
Allows release branches to run build

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -2,9 +2,9 @@ name: .NET Core
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, release* ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, release* ]
 
 jobs:
   build:


### PR DESCRIPTION
This activates `release` branches for builds, which will allow for beta packages to be deployed to Github Packages.